### PR TITLE
androidの日本語で適用されるフォントはコピーライトの記号のスタイルが変更されない。

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="en" prefix="og: http://ogp.me/ns#">
+<html class="no-js" lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/src/component/contents/TheGlobalFooter.vue
+++ b/src/component/contents/TheGlobalFooter.vue
@@ -69,5 +69,6 @@ export default {
     #copyright {
         margin-top: 1em;
         color: #EEEEEE;
+        font-family: Roboto, Arial, Helvetica, Tahoma, Verdana;
     }
 </style>


### PR DESCRIPTION
また、langをenにすると自動翻訳のポップアップが表示されるようになってしまう。